### PR TITLE
Add udev generation and salt script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ for permanent switch os(with no version) install to latest image as default
 
 ### Pelagos unit tests
 
-Unit tests are in 'test'  subdir and could be executed via
+Unit tests are in 'test' subdir and could be executed via
 
     python test/test_pelagos.py
 
@@ -203,7 +203,7 @@ Teuthology integration could be tested via  executing 2 commands:
 
 1. Run Pelagos in python pelgos env
 
-        python bin/pelagos.py -c test_pelagos_teuthology/test_network_cfg.json --simulate=fast  --tftp-dir=/tmp/tftp
+        python bin/pelagos.py --config test_pelagos_teuthology/test_network_cfg.json --simulation=fast  --tftpdir=/tmp/tftp
 
 2. Run test in teuthology env with adding teuthology lib
 

--- a/bin/make_cfgs.py
+++ b/bin/make_cfgs.py
@@ -34,6 +34,11 @@ for teuthology generates sql script <target dir>/sql/nodes.sql
     INSERT INTO nodes (name, machine_type, mac_address, is_vm, locked, arch, description)
         VALUES  ( 'ses-client-3.a.b.de' , 'client' ,
             'aa:bb:cc:dd:67:16' , 'f' , 'f' , 'x86-64' , '' ) ;
+
+also generated udev rules file for predefined network names setup
+    #ses-client-1
+    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="aa:bb:cc:dd:67.16", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="eth0"
+
 """
 
 parser = argparse.ArgumentParser(description=description,
@@ -47,6 +52,10 @@ def reverse_ip(ip):
 def short_hostname(fqdn):
     return fqdn.split('.')[0]
 
+#some magic
+mgmt_nic = 'eth0'
+hsm_start_number = 2
+hsm_prefix  = 'eth'
 
 # hardcoded but should be parametrized
 pxe_output_file = 'states/etc/dnsmasq/dnsmasq.d/network_nodes.conf'
@@ -59,6 +68,7 @@ bmc_pass = ""
 domain = ""
 
 sql_script_file = 'sql/nodes.sql'
+udev_file = 'udev/70-persistent-net.rules'
 sql_line_prefix = 'INSERT INTO nodes ' \
                   '(name, machine_type, mac_address, is_vm, ' \
                   'locked, arch, description) VALUES '
@@ -87,6 +97,7 @@ roster_recors = ""
 pxe_node_lines = []
 pxe_node_ptr_lines = []
 nodes_sql_lines = []
+udev_lines = []
 
 for n in nodes:
     print('Process node' + n['node'])
@@ -145,16 +156,32 @@ for n in nodes:
             ]
         nodes_sql_lines.append(
             sql_line_prefix +\
-            " ( " + " , ".join(sql_update_body) + " ) ;\n"
+            " ( " + ", ".join(sql_update_body) + " ) ;\n"
         )
 
+    udev_lines.append(
+        (   "#predefined rules for node  '%s'\n" % (n['node'])+\
+            'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*",' +\
+            ' ATTR{address}=="%s",' % (n['mac']) +\
+            ' KERNEL=="eth*", NAME="%s" \n' % mgmt_nic
+        )
+    )
+    if 'hsm_mac' in n.keys() and isinstance(n['hsm_mac'], list):
+        for i in range(0, len(n['hsm_mac'])):
+            udev_lines.append(
+                'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*",' +\
+                ' ATTR{address}=="%s",' % n['hsm_mac'][i] +\
+                ' KERNEL=="eth*", NAME="eth%d" \n' % (hsm_start_number + i)
+            )
 
+# ----------- pxe ---------------
 with open(target_dir_prefix + pxe_output_file, 'w') as ofile:
     ofile.write("\n".join(pxe_node_lines)+"\n")
     ofile.write("\n".join(pxe_node_ptr_lines)+"\n")
 print("File [{}] written".format(target_dir_prefix +
                                     pxe_output_file))
 
+# ----------- conman ---------------
 lines = ""
 with open(target_dir_prefix + conman_tmpl, "r") as cf:
     for line in cf:
@@ -165,12 +192,21 @@ with open(target_dir_prefix + conman_cfg, 'w') as ofile:
     ofile.write(lines)
 print("File [{}] written".format(target_dir_prefix + conman_cfg))
 
+# ----------- roster ---------------
 with open(target_dir_prefix + roster_file, 'w') as ofile:
     ofile.write(roster_recors)
 print("File [{}] written".format(target_dir_prefix + roster_file))
+
+# ----------- sql file ---------------
 
 with open(target_dir_prefix + sql_script_file, 'w') as ofile:
     ofile.write("".join(nodes_sql_lines))
 print("File [{}] written".format(target_dir_prefix +
                                      sql_script_file))
+
+# ----------- udev file ---------------
+udev_path = target_dir_prefix + udev_file
+with open(udev_path, 'w') as ofile:
+    ofile.write("".join(udev_lines))
+print("File [{}] written".format(udev_path))
 

--- a/lib/hw_node.py
+++ b/lib/hw_node.py
@@ -15,29 +15,38 @@ ipmi_pass = ''
 target_pass =''
 roster_file = 'deploy.roster'
 salt_cfg_dir  = '.'
+sls_list = []
 
 def init():
+    global ipmi_user
     ipmi_user = network_manager.get_option('ipmi_user')
+    global ipmi_pass
     ipmi_pass = network_manager.get_option('ipmi_pass')
-
+    global target_pass
     target_pass = network_manager.get_option(
         'target_node_password')
 
     if network_manager.get_option('roster_file'):
+        global roster_file
         roster_file = network_manager.get_option(
-            'roster_file')
+            'roster_file', roster_file)
 
     if network_manager.get_option('salt_cfg_dir'):
-        salt_cfg_dir = network_manager.get_option(
-            'salt_cfg_dir')
+        global salt_cfg_dir
+        salt_cfg_dir= network_manager.get_option(
+            'salt_cfg_dir', salt_cfg_dir)
 
+    if network_manager.get_option('sls_list'):
+        global sls_list
+        sls_list = [x.strip() for x in \
+            network_manager.get_option('sls_list').split(',')]
 
 
 def get_ipmi_cycle_cmd(ip, user='', passwd=''):
     if not user:
         user = ipmi_user
     if not passwd:
-        user = ipmi_pass
+        passwd = ipmi_pass
 
     return "{} -H {} -U {} -P {} -I lanplus power cycle".\
             format(ipmitool_bin, ip, user, passwd)
@@ -49,8 +58,8 @@ def get_conman_cmd(server, name):
 def get_salt_cmd(sls, node):
     return 'salt-ssh -i --roster-file ' + roster_file +\
                     ' -c ' + salt_cfg_dir +\
-                    ' --no-host-keys --key-deploy ' +\
-                    '--passwd ' + target_pass  +\
+                    ' --no-host-keys --key-deploy' +\
+                    ' --passwd ' + target_pass  +\
                     ' "' + node + '" ' +\
                     ' state.apply ' + sls + ' -l debug'
 
@@ -81,7 +90,7 @@ def wait_node_is_ready(node, timeout=5, attempts=120):
 
 
 def minimal_needed_configuration(node, timeout=60):
-    for sls in ["setup_hsm", "configure_services"]:
+    for sls in sls_list:
         local = LocalNode()
         local.pwd()
         local.shell(get_salt_cmd(sls, node['node']))

--- a/lib/network_manager.py
+++ b/lib/network_manager.py
@@ -14,8 +14,10 @@ def load_data_file():
         data = json.load(json_file)
     return data
 
-def get_option(opt_name):
-    return load_data_file()[opt_name]
+def get_option(opt_name, default_value=""):
+    if opt_name in load_data_file():
+        return load_data_file()[opt_name]
+    return default_value
 
 def get_nodes():
     return load_data_file()['nodes']

--- a/test/test_hw_node.json
+++ b/test/test_hw_node.json
@@ -1,12 +1,12 @@
 {
 "default_pxe_server": "10.162.230.2",
 "ipmi_user": "oroot",
-"ipmi_pass": "hammer23",
-"target_node_password": "hammer23",
+"ipmi_pass": "ipmi_passs",
+"target_node_password": "ssh_pass",
 "maintenance_image_kernel": "opensuse-leap-15.0.x86_64-0.0.1-4.12.14-lp150.11-default.kernel",
 "maintenance_image_initrd": "opensuse-leap-15.0-image.x86_64-0.0.1.initrd.xz",
-"salt_cfg_dir": "/tmp/saltcfg",
-"roster_file": "/tmp/roster",
+"roster_file": "deploy.roster",
+"sls_list": "setup_hsm, configure_services",
 "nodes":[
   {
       "node":         "ses-client-8",

--- a/test/test_hw_node.py
+++ b/test/test_hw_node.py
@@ -29,7 +29,7 @@ class pxelinux_cfg_test(unittest.TestCase):
         hw_node.init()
         cmd  = hw_node.get_salt_cmd('test_sls', 'test_node')
         self.assertEqual(cmd,
-        'salt-ssh -i --roster-file deploy.roster -c . --no-host-keys --key-deploy --passwd  "test_node"  state.apply test_sls -l debug')
+        'salt-ssh -i --roster-file deploy.roster -c . --no-host-keys --key-deploy --passwd ssh_pass "test_node"  state.apply test_sls -l debug')
 
 
     #TODO should be used when conman suppot added to teuthology

--- a/test/test_network_cfg.json
+++ b/test/test_network_cfg.json
@@ -7,7 +7,9 @@
   "maintenance_image_initrd": "opensuse-leap-15.0-image.x86_64-0.0.1.initrd.xz",
   "default_pxe_server": "127.0.0.1",
   "domain": "suse.de",
-
+  "roster_file": "deploy.roster",
+  "salt_cfg_dir": "/tmp/saltcfg",
+  "sls_list": "setup_hsm, configure_services",
   "nodes":[
   {
     "node":        "head",

--- a/test/test_pelagos.py
+++ b/test/test_pelagos.py
@@ -153,7 +153,7 @@ class pelagosTest(unittest.TestCase):
         logging.debug(prefix + " TaskID: " + taskid)
         response_1 = self.app.get(location)
         logging.debug(prefix + "next level response headers")
-        logging.debug(response_1.headers)        
+        logging.debug(response_1.headers)
         self.assertEqual(response_1.status, next_level_status, prefix)
         return location, taskid
 

--- a/test_pelagos_teuthology/test_network_cfg.json
+++ b/test_pelagos_teuthology/test_network_cfg.json
@@ -1,12 +1,14 @@
 {
-  
   "ipmi_user": "root",
   "ipmi_pass": "password",
   "target_node_password": "password",
   "maintenance_image_kernel": "opensuse-leap-15.0.x86_64-0.0.1-4.12.14-lp150.11-default.kernel",
   "maintenance_image_initrd": "opensuse-leap-15.0-image.x86_64-0.0.1.initrd.xz",
   "default_pxe_server": "127.0.0.1",
-
+  "domain": "suse.de",
+  "roster_file": "/tmp/roster",
+  "salt_cfg_dir": "/tmp/saltcfg",
+  "sls_list": "setup_hsm, configure_services",
   "nodes":[
   {
       "node":        "head",

--- a/test_pelagos_teuthology/test_pelagos.py
+++ b/test_pelagos_teuthology/test_pelagos.py
@@ -1,10 +1,8 @@
 from copy import deepcopy
 
-#from mock import patch, DEFAULT, PropertyMock
 from pytest import raises, mark
 
 from teuthology.config import config
-#from teuthology.exceptions import MaxWhileTries
 from teuthology.provision import pelagos
 import teuthology.parallel
 
@@ -26,11 +24,7 @@ class TestPelagos(object):
     def setup(self):
         config.load(deepcopy(test_config))
 
-    #    def teardown(self):
-
     def test_get_types(self):
-        # with patch('teuthology.provision.pelagos.enabled') as m_enabled:
-        #    m_enabled.return_value = enabled
 
         types = pelagos.get_types()
         assert types == test_config['pelagos']['machine_types'].split(',')


### PR DESCRIPTION
bin/make_cfgs.py: added generation of  udev rules
README.md: updated  documentation
network_manager, hw_node.py: added support of salt files in other directories
some updates in tests and test configurations