### PR TITLE
Add  command for booting to live image

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,25 @@ For manual node configuration could be used salt commands:
 ## Provision
 
 Warning! curl commands is subject for change
-    os = request.form['os']
-    node_id = request.form['node']
+
+* 'os' - os version which used for boot. It compatible with
+        teuthology format, e.g. could be ' sle-15.1'. Also
+        supported 2 special 'os'-es:
+         - 'local' - boot for local disk
+         - 'maintenance_image' - maintenance disk ram-only image, also it
+            used as 'parking' image in unlock command
+
+
+* 'node' -
 
 For provision one node for testing boot could be use cmd.
 
-        curl -i http://<server ip>:5000/node/provision -X POST -d {"os":"<dir name from tftp>", "node":"<nodename from configuration>"}
+    curl -i http://<server ip>:5000/node/provision -X POST \
+    -F 'os=_distro name_' -F 'node=_node name from cfg_'
 
 Provisioning status could be observed
 
-        curl  http://<server ip>:5000/tasks/statuses
+    curl  http://<server ip>:5000/tasks/statuses
 
 for permanent switch os(with no version) install to latest image as default
 

--- a/README.md
+++ b/README.md
@@ -176,19 +176,19 @@ For manual node configuration could be used salt commands:
 Warning! curl commands is subject for change
 
 * 'os' - os version which used for boot. It compatible with
-        teuthology format, e.g. could be ' sle-15.1'. Also
+        teuthology format, e.g. can be ' sle-15.1'. Also
         supported 2 special 'os'-es:
          - 'local' - boot for local disk
          - 'maintenance_image' - maintenance disk ram-only image, also it
             used as 'parking' image in unlock command
 
 
-* 'node' -
+* 'node' - node name as defined in pelagos configuration
 
 For provision one node for testing boot could be use cmd.
 
     curl -i http://<server ip>:5000/node/provision -X POST \
-    -F 'os=_distro name_' -F 'node=_node name from cfg_'
+    -F 'os=<os>' -F 'node=<node>'
 
 Provisioning status could be observed
 

--- a/bin/pelagos.py
+++ b/bin/pelagos.py
@@ -57,8 +57,10 @@ def _check_input_node(node_id):
 def _check_input_os(os):
     if not len(os):
         abort(404, "No OS string [{}] found".format(os))
-    if os == 'local':
+    if os == pxelinux_cfg.id_local_boot:
         return pxelinux_cfg.id_local_boot
+    if os == pxelinux_cfg.id_maintenance_boot:
+        return pxelinux_cfg.id_maintenance_boot
     # list tftp dir and find all dirs, compare it with
     # required os and do fuzzy selection
     app.logger.info('Searching os  %s on disk', os)
@@ -187,6 +189,7 @@ if __name__ == '__main__':
         'default_pxe_server')
 
     hw_node.init()
+    pxelinux_cfg.init()
 
     app.run(debug=True, host='0.0.0.0', threaded=True)
         # False, processes=10)

--- a/lib/pxelinux_cfg.py
+++ b/lib/pxelinux_cfg.py
@@ -68,9 +68,9 @@ LABEL mainmenu
 pxe_common_os_boot_tmpl = '''
 
 LABEL oem linux
-  KERNEL {}/pxeboot.kernel
-  INITRD {}/pxeboot.initrd.xz
-  APPEND  biosdevname=0 net.ifnames=0  rd.kiwi.install.pxe rd.kiwi.install.image=http://{}/{}/{}.xz console=tty1 console=ttyS1,115200 kiwidebug=1
+  KERNEL {os}/pxeboot.kernel
+  INITRD {os}/pxeboot.initrd.xz
+  APPEND  biosdevname=0 net.ifnames=0  rd.kiwi.install.pxe rd.kiwi.install.image=http://{server}/{os}/{image}.xz console=tty1 console=ttyS1,115200 kiwidebug=1
   MENU DEFAULT
 
 '''
@@ -118,8 +118,9 @@ def get_boot_record_for_os(node, os_id):
         image = re.compile('^oem-').sub('', os_id)
         image = re.compile('-\d+\.\d+\.\d+').sub('', image)
         cfg = pxe_common_os_boot_tmpl.format(
-                            os_id, os_id,
-                            default_pxe_server, os_id, image)
+                            os=os_id,
+                            server=default_pxe_server,
+                            image=image)
     return "# os={}\n".format(os_id) + \
            "# node={}\n".format(node['node']) + \
             pxe_common_settings + cfg + pxe_main_menu_submenu
@@ -212,8 +213,9 @@ def refresh_mainmenu():
         image = re.compile(r'^oem-').sub('', os_image_dir)
         image = re.compile(r'-\d+\.\d+\.\d+').sub('', image)
         disto_menu = disto_menu + pxe_common_os_boot_tmpl.format(
-            os_image_dir, os_image_dir, default_pxe_server,
-            os_image_dir, image)
+            os=os_image_dir,
+            server=default_pxe_server,
+            image=image)
 
     logging.debug("Write new pxe configuration: " + cfg_file)
     with open(cfg_file, 'w') as ofile:


### PR DESCRIPTION
Added command to boot to live maintenance os image for allowing it to use as a parking state for teuthology.
lib/pxelinux_cfg.py  - fixed menu generation, added configuration reading
README.md - improved documentation
bin/pelagos.py - added code for pointing on maintenance image
