### PR TITLE
Added logging to files and REST request for read log per node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 master
 deploy.roster
 .env
+.pytest_cache

--- a/.pytest_cache/README.md
+++ b/.pytest_cache/README.md
@@ -1,8 +1,0 @@
-# pytest cache directory #
-
-This directory contains data from the pytest's cache plugin,
-which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
-
-**Do not** commit this to version control.
-
-See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.

--- a/.pytest_cache/README.md
+++ b/.pytest_cache/README.md
@@ -1,0 +1,8 @@
+# pytest cache directory #
+
+This directory contains data from the pytest's cache plugin,
+which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
+
+**Do not** commit this to version control.
+
+See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.

--- a/bin/pelagos.py
+++ b/bin/pelagos.py
@@ -140,7 +140,7 @@ def rmbootrecord_node(node_id):
 @app.route('/node/provision', methods=['POST'])
 @async_task
 def provision_node():
-    # start separated logging ASAP
+    # start logging for new thread to file ASAP
     # cleanup in flask 'clean_old_taks'
     threaded_logging.start()
     if request.method != 'POST':

--- a/lib/flask_tasks.py
+++ b/lib/flask_tasks.py
@@ -66,7 +66,6 @@ def before_first_request():
         while not stop_cleanup:
             # Only keep tasks that are running or finished less than
             # data_life_time sec ago.
-            # logging.debug("###run cleanups")
             current_time = timestamp()
             cleanup_list = [i for i, t in tasks.items()
                             if 'endtime' in t and

--- a/lib/flask_tasks.py
+++ b/lib/flask_tasks.py
@@ -64,7 +64,7 @@ def before_first_request():
         """
         global tasks, stop_cleanup
         while not stop_cleanup:
-            # Only keep tasks that are running or that finished less than
+            # Only keep tasks that are running or finished less than
             # data_life_time sec ago.
             # logging.debug("###run cleanups")
             current_time = timestamp()

--- a/lib/hw_node.py
+++ b/lib/hw_node.py
@@ -94,8 +94,12 @@ def power_cycle(node):
         local.shell(cmd, trace=True)
     except:
         BMCException(sys.exc_info()[1])
+
+    logging.debug('Status:', local.status)
+    logging.debug('Output:', local.stdout.rstrip())
+    logging.debug('Errors:', local.stderr)
     if local.status == 0:
-        print("node restarted")
+        logging.debug("node restarted")
         # TODO check retrun results from results
     else:
         raise BMCException(
@@ -206,8 +210,8 @@ def minimal_needed_configuration(node, timeout=60, extra_sls=[]):
         local = LocalNode()
         local.pwd()
         local.shell(get_salt_cmd(sls, node['node']))
-        print('Status:', local.status)
-        print('Output:', local.stdout.rstrip())
-        print('Errors:', local.stderr)
+        logging.debug('Status:', local.status)
+        logging.debug('Output:', local.stdout.rstrip())
+        logging.debug('Errors:', local.stderr)
     logging.debug('Executed salt script[{}]'.format(full_sls))
     return local

--- a/lib/hw_node.py
+++ b/lib/hw_node.py
@@ -94,7 +94,6 @@ def exec_bmc_command(node, ipmi_command):
     except:
         BMCException(sys.exc_info()[1])
     logging.debug('Status:' + str(local.status))
-    logging.debug('Status:' + str(local.status))
     logging.debug('Output:' + local.stdout.rstrip())
     logging.debug('Errors:' + local.stderr)
     if local.status == 0:
@@ -195,7 +194,7 @@ def wait_node_is_ready(node,
             logging.debug("Connected to node %s " % node['node'])
             return True
         except:
-            logging.error("Node {} have not started in timeout {}".format(
+            logging.debug("Node {} have not started in timeout {}".format(
                 node['node'], port_lookup_timeout))
 
     raise TimeoutException("{} have not started in timeout {}".format(

--- a/lib/pxelinux_cfg.py
+++ b/lib/pxelinux_cfg.py
@@ -225,7 +225,7 @@ def provision_node_simulate_failure(node, os_id):
 
 def provision_node(node, os_id, extra_sls=[]):
     set_tftp_dir(node, os_id)
-    hw_node.power_cycle(node)
+    hw_node.exec_bmc_command(node, 'power cycle')
     time.sleep(default_undoubted_hw_start_timeout)
     hw_node.wait_node_is_ready(node, timeout=wait_node_is_ready_timeout)
     if not (os_id == id_local_boot or

--- a/lib/threaded_logging.py
+++ b/lib/threaded_logging.py
@@ -1,0 +1,89 @@
+import logging
+import logging.config
+import threading
+
+log_prefix = '/tmp/'
+thread_pelagos_log = None
+thread_log_tmpl = ''
+root_log_file = None
+formatter = "%(asctime)-15s" \
+            "| %(processName)-10s" \
+            "| %(threadName)-11s" \
+            "| %(levelname)-5s" \
+            "| %(message)s"
+
+
+class ThreadedFilter(logging.Filter):
+    """
+    This filter only show log entries for specified thread name
+    """
+
+    def __init__(self, thread_name, *args, **kwargs):
+        logging.Filter.__init__(self, *args, **kwargs)
+        self.thread_name = thread_name
+
+    def filter(self, record):
+        return record.threadName == self.thread_name
+
+
+def config_root_logger():
+    global thread_pelagos_log, thread_log_tmpl, root_log_file
+    thread_pelagos_log = log_prefix + 'pelagos.log'
+    thread_log_tmpl = log_prefix + 'pelagos_thrd_log-{}.log'
+    root_log_file = log_prefix + 'pelagos_root.log'
+
+    logging.config.dictConfig({
+        'version': 1,
+        'formatters': {
+            'root_formatter': {
+                'format': formatter
+            }
+        },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                'formatter': 'root_formatter'
+            },
+            'log_file': {
+                'class': 'logging.FileHandler',
+                'level': 'DEBUG',
+                'filename': root_log_file,
+                'formatter': 'root_formatter',
+            }
+        },
+        'loggers': {
+            '': {
+                'handlers': [
+                    'console',
+                    'log_file',
+                ],
+                'level': 'DEBUG',
+                'propagate': True
+            }
+        }})
+
+
+def get_log_name(thread_name):
+    return thread_log_tmpl.format(thread_name)
+
+
+def start(thread_name=None):
+    if thread_name is None:
+        thread_name = threading.Thread.getName(
+            threading.current_thread())
+    logging.debug('New log name is:' +
+                  thread_log_tmpl.format(thread_name))
+    log_handler = logging.FileHandler(
+            get_log_name(thread_name)
+        )
+    log_handler.setLevel(logging.DEBUG)
+    log_handler.setFormatter(
+        logging.Formatter(formatter)
+    )
+
+    log_filter = ThreadedFilter(thread_name)
+    log_handler.addFilter(log_filter)
+
+    logging.getLogger().addHandler(log_handler)
+    return log_handler

--- a/lib/threaded_logging.py
+++ b/lib/threaded_logging.py
@@ -69,7 +69,7 @@ def get_log_name(thread_name):
 
 
 def start(thread_name=None):
-    if thread_name is None:
+    if not thread_name:
         thread_name = threading.Thread.getName(
             threading.current_thread())
     logging.debug('New log name is:' +

--- a/test/test_hw_node.py
+++ b/test/test_hw_node.py
@@ -4,7 +4,7 @@ import network_manager
 import hw_node
 
 
-class pxelinux_cfg_test(unittest.TestCase):
+class Hw_node_test(unittest.TestCase):
 
     def test_hw_node_ipmitool(self):
         network_manager.data_file = 'test/test_network_cfg.json'
@@ -13,13 +13,14 @@ class pxelinux_cfg_test(unittest.TestCase):
 
         node = network_manager.get_node_by_name('test_node')
 
-        cmd = hw_node.get_ipmi_cycle_cmd('1.2.3.4', 'user', 'password')
+        cmd = hw_node.get_ipmi_cmd('1.2.3.4', 'power cycle',
+                                   'user', 'password')
         self.assertEqual(cmd,
                          'ipmitool -H 1.2.3.4 -U user ' +
                          '-P password -I lanplus power cycle'
                          )
         hw_node.ipmitool_bin = 'echo'
-        hw_node.power_cycle(node)
+        hw_node.exec_bmc_command(node, 'power cycle')
 
     def test_hw_node_salt_ssh(self):
         network_manager.data_file = 'test/test_hw_node.json'
@@ -43,13 +44,16 @@ class pxelinux_cfg_test(unittest.TestCase):
             '2020-01-29 21:20:31 Welcome to openSUSE'))
 
     def test_wait_node_is_ready(self):
-        node = {'node': 'test_node1.domain.net',
-                'ip': '127.0.0.1'}
+        network_manager.data_file = 'test/test_hw_node.json'
+        hw_node.init()
+        node = network_manager.get_node_by_name('ses-client-8')
         hw_node.conman_log_prefix = 'test/conman.console.'
+        hw_node.ipmitool_bin = 'echo'
+        hw_node.default_cold_restart_timeout = 1
 
         with self.assertRaises(hw_node.CannotBootException):
             hw_node.wait_node_is_ready(node,
-                                       timeout=10,
+                                       timeout=20,
                                        conman_line_max_age=5,
                                        max_cold_restart=1,
                                        port_lookup=20,
@@ -64,6 +68,7 @@ class pxelinux_cfg_test(unittest.TestCase):
                                        port_lookup=20,
                                        port_lookup_attempts=3,
                                        port_lookup_timeout=1)
+        node['ip'] = '127.0.0.1'
         res = hw_node.wait_node_is_ready(node)
         self.assertTrue(res)
 

--- a/test/test_pelagos.py
+++ b/test/test_pelagos.py
@@ -30,8 +30,8 @@ class pelagosTest(unittest.TestCase):
 
     def setUp(self):
         network_manager.data_file = 'test/test_network_cfg.json'
-        flask_tasks.clean_call_timeout = 1
-        flask_tasks.data_life_time = 300
+        flask_tasks.clean_call_timeout_sec = 1
+        flask_tasks.data_life_time_sec = 300
         # set flask sent trace to console
         pelagos.app.testing = True
         self.app = pelagos.app.test_client()
@@ -207,7 +207,7 @@ class pelagosTest(unittest.TestCase):
              'node': 'test_node'},
             'provision timeout test')
         logging.debug('Wait for bmc failure')
-        time.sleep(20)
+        time.sleep(30)
         response_3 = self.app.get(location)
         logging.debug('next level response headers #3')
         logging.debug(response_3.get_data())
@@ -243,12 +243,13 @@ class pelagosTest(unittest.TestCase):
         # frozen conman output/max restarts
         pxelinux_cfg.wait_node_is_ready_timeout = 30
         hw_node.default_conman_line_max_age = 3
+        hw_node.default_cold_restart_timeout = 1
         location, tid = self.do_flask_task_request(
             '/node/provision',
             {'os': os_id,
                 'node': 'test_node'},
             'provision timeout test')
-        logging.debug('Wait for server reaction 120s')
+        logging.debug('Wait for server reaction')
         time.sleep(20)
         response_5 = self.app.get(location)
         logging.debug('next level response headers #5')
@@ -264,7 +265,7 @@ class pelagosTest(unittest.TestCase):
         # - wait for end of cleanup time
         # - check log cleanup
 
-        flask_tasks.data_life_time = 5
+        flask_tasks.data_life_time_sec = 5
         time.sleep(10)
         location, tid = self.do_flask_task_request(
             '/node/provision',


### PR DESCRIPTION
Now logs messages are sent to console and files, one log file per provision thread(request) and one log file for the main thread.
Log files are stored in /tmp/pelagos*
Added request <host:port>/tasks/get/<id> for receiving log files via REST interface, one file per one request.