### PR TITLE
Add dismiss provision control functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ as user on build node:
 
 ## Configuration
 
-For manual node configuration could be used salt commands:
+For manual provisioned node configuration could be used salt commands:
 
     sudo -u salt salt-ssh -i --roster-file deploy.roster --key-deploy --passwd <password> -c . '<node name without domain>' state.apply setup_hsm
 
-## Provision
+## Provisioning
 
 Warning! curl commands is subject for change
 
@@ -209,6 +209,22 @@ Provisioning status could be observed
 for permanent switch os(with no version) install to latest image as default
 
     ... TBD ...
+
+## Reprovisioning and dissmissing provision
+
+Pelagos do some actions after provision start: change boot files,
+observer conman log files, trying to connect to a target node and so on,
+in some cases a provision thread could decide to reboot a node. All that
+activity could be problematic for a concurrent provision and re-provision. 
+
+For solving it, added a special functionality for a dismissing provision for
+specific node. It prevents 2 and more simultaneous provisions for one node.
+For REST 'node/provision' the functionality call automatically.
+
+Also, there is special call '/node/dismiss' if a user want to do it explicitly.
+Parameters are: 
+* 'node' - a node name from the configuration file which should be dismissed
+    from control a thread
 
 ## Test execution
 

--- a/lib/flask_tasks.py
+++ b/lib/flask_tasks.py
@@ -2,9 +2,10 @@
 # mostly copied from https://github.com/miguelgrinberg/flack/commit/0c372464b341a2df60ef8d93bdca2001009a42b5?diff=unified
 # video https://www.youtube.com/watch?v=tdIIJuPh3SI&feature=youtu.be
 #
-import os
+import ctypes
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -24,11 +25,32 @@ logging.basicConfig(format='%(asctime)s | %(name)s | %(message)s',
 
 tasks_bp = Blueprint('tasks', __name__)
 tasks = {}
+tasks_mutex = threading.Lock()
 testing = False
 data_life_time_sec = 12 * 60 * 60
 clean_call_timeout_sec = 60
 cleanup_thread = None
 stop_cleanup = False
+
+
+class NoTaskException(Exception):
+    """Raised when no task found/detected"""
+    pass
+
+
+class NoThreadException(Exception):
+    """Raised when thread cannot be found"""
+    pass
+
+
+class CannotDismissNode(Exception):
+    """Raised when node dismiss failed"""
+    pass
+
+
+class StopThread(Exception):
+    """Raised when node dismiss failed"""
+    pass
 
 
 def timestamp():
@@ -66,12 +88,14 @@ def before_first_request():
             # Only keep tasks that are running or finished less than
             # data_life_time_sec ago.
             current_time = timestamp()
+            tasks_mutex.acquire()
             cleanup_list = [i for i, t in tasks.items()
                             if 'endtime' in t and
                             t['endtime'] > -1 and
                             current_time - t['endtime'] > data_life_time_sec]
             for i in cleanup_list:
                 os.remove(tasks.pop(i)['log_file'])
+            tasks_mutex.release()
             time.sleep(clean_call_timeout_sec)
 
     logging.debug('Run cleanup thread')
@@ -90,9 +114,19 @@ def async_task(target_func):
             # Create a request context similar to that of the original request
             # so that the task can have access to flask.g, flask.request, etc.
             with app.request_context(environ):
+                node_id = request.form['node']
                 try:
+                    logging.debug('Dismiss node %s' % node_id)
+                    try:
+                        stop_thread_for_node(node_id)
+                    except NoTaskException:
+                        logging.debug('Thread for node is not found, continue')
+                    except NoThreadException:
+                        logging.debug('Node is not found by task, continue')
                     # Run the route function and record the response
                     logging.debug("Executing target function")
+                    tasks[task_id]['node'] = node_id
+                    tasks[task_id]['os'] = request.form['os']
                     tasks[task_id]['thread_name'] = threading.Thread.getName(
                         threading.current_thread())
                     tasks[task_id]['log_file'] = threaded_logging. \
@@ -100,6 +134,7 @@ def async_task(target_func):
                     tasks[task_id]['starttime'] = timestamp()
                     tasks[task_id]['endtime'] = -1
                     tasks[task_id]['started'] = True
+                    tasks[task_id]['stopped'] = False
                     tasks[task_id]['rv'] = target_func(*args, **kwargs)
                 except HTTPException as e:
                     logging.debug("Caught http exception:" + str(e))
@@ -107,10 +142,15 @@ def async_task(target_func):
                         current_app.handle_http_exception(e)
                     traceback.print_exc(file=sys.stdout)
                 except Exception as e:
-                    logging.debug("Caught exception:" + str(e))
+                    logging.debug("Caught Exception:" + str(e))
+                    logging.error("Caught Exception:%s" % sys.exc_info()[1])
                     # The function raised an exception, so we set a 500 error
                     tasks[task_id]['rv'] = InternalServerError()
                     traceback.print_exc(file=sys.stdout)
+                except:
+                    tasks[task_id]['rv'] = InternalServerError()
+                    msg = "Oops in flask_task! %s occured." % sys.exc_info()[1]
+                    logging.error(msg)
                 finally:
                     # We record the time of the response, to help in garbage
                     # collecting old tasks
@@ -121,9 +161,12 @@ def async_task(target_func):
         task_id = uuid.uuid4().hex
 
         # Record the task, and then launch it
+        tasks_mutex.acquire()
         tasks[task_id] = {'task': threading.Thread(
             target=task, args=(current_app._get_current_object(),
                                request.environ))}
+        tasks_mutex.release()
+        tasks[task_id]['task'].daemon = True
         tasks[task_id]['task'].start()
         # wait is needed for case when many requests is done
         # and new thread starting took time
@@ -132,7 +175,7 @@ def async_task(target_func):
             i = i + 1
             if 'started' in tasks[task_id]:
                 break
-            time.sleep(1)
+            time.sleep(3)
         if 'started' not in tasks[task_id]:
             tasks[task_id]['rv'] = InternalServerError(
                 'Too long async thread starts')
@@ -162,6 +205,9 @@ def get_status(id):
                          'StartTime': task['starttime'],
                          'EndTime': task['endtime'],
                          'TaskID': id,
+                         'Node': task['node'],
+                         'OS': task['os'],
+                         'stopped': task['stopped'],
                          'status': 'not completed'}
     return task['rv']
 
@@ -176,12 +222,15 @@ def get_statuses():
     # logging.info('List current active provisions')
     # logging.debug("tasks:")
     res = dict()
-    for task in tasks:
+    for task in tasks.copy():
         # logging.debug(tasks[task])
         # logging.debug(tasks[task]['starttime'])
         t = dict()
         t['start_time'] = tasks[task]['starttime']
         t['end_time'] = tasks[task]['endtime']
+        t['node'] = tasks[task]['node']
+        t['os'] = tasks[task]['os']
+        t['stopped'] = tasks[task]['stopped']
         if 'rv' in tasks[task]:
             rv = tasks[task]['rv']
             t['rv'] = json.loads(
@@ -205,6 +254,66 @@ def get_log(task_id):
     return jsonify({'TaskID': task_id, 'LogData': data})
 
 
-@tasks_bp.route('/cancel/<id>', methods=['GET'])
-def cancel_provision(node_id):
-    abort(404, "No node [{}] found".format(node_id))
+def find_taks_by_node(node_id):
+    for t in tasks.copy().keys():
+        logging.debug('Check node:' + str(tasks[t]))
+        if 'node' in tasks[t].keys() and tasks[t]['node'] == node_id:
+            return t
+    raise NoTaskException('Cannot find task for "%s" node' % node_id)
+
+
+def find_thread_by_task(task_id):
+    if not(task_id in tasks.keys()):
+        raise NoTaskException('No task "%s" found' % task_id)
+    for tid, tobj in threading._active.copy().items():
+        logging.debug('Check TID %s' % str(tid))
+        if tobj is tasks[task_id]['task']:
+            logging.debug('TID set %s' % str(tid))
+            return tid, tobj
+    raise NoThreadException('No thread for task "%s" was found' % task_id)
+
+
+def stop_thread_for_node(node_id):
+    task = find_taks_by_node(node_id)
+    thr_id, thr_obj = find_thread_by_task(task)
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_long(thr_id), ctypes.py_object(StopThread))
+    if res == 0:
+        logging.error('Exception raise failure, no target found')
+        raise CannotDismissNode('Cannot find thread for raising exception')
+    elif res > 1:
+        logging.error('Too many thread found')
+        raise CannotDismissNode('')
+    else:
+        tasks[task]['task'].join()
+        tasks[task]['stopped'] = True
+        logging.debug('Exception raised successfully')
+
+
+# node - should be node id in configuration file
+@tasks_bp.route('/node/dismiss', methods=['POST'])
+def dismiss_node():
+    node_id = request.form['node']
+    logging.info('Dismissing provision task for node "{}"'.format(node_id))
+    # logging.debug(tasks)
+    try:
+        stop_thread_for_node(node_id)
+    except CannotDismissNode as cdn_exc:
+        msg = 'Caught CannotDismissNode %s' % cdn_exc
+        logging.info(msg)
+        abort(503, msg)
+    except NoTaskException as ntask_exp:
+        msg = 'Caught NoTaskException %s' % ntask_exp
+        logging.info(msg)
+        abort(404, msg)
+    except NoThreadException as nthr_exp:
+        msg = 'Caught NoThreadException %s' % nthr_exp
+        logging.info(msg)
+        abort(404, msg)
+    except:
+        msg = "Oops! In dismiss_node  %s occured." % sys.exc_info()[1]
+        logging.error(msg)
+        abort(501, msg)
+
+    return jsonify({'status': 'dedicated boot record removed',
+                    'node': node_id})

--- a/lib/hw_node.py
+++ b/lib/hw_node.py
@@ -1,5 +1,6 @@
-
+from flask_tasks import StopThread
 from node import LocalNode
+
 import logging
 import network_manager
 import re
@@ -201,7 +202,9 @@ def wait_node_is_ready(node,
                                 attempts=port_lookup_attempts)
             logging.debug("Connected to node %s " % node['node'])
             return True
-        except:
+        except StopThread as st:
+            raise StopThread
+        except Exception as es:
             logging.debug("Node {} have not started in timeout {}".format(
                 get_provision_ip(node), port_lookup_timeout))
 

--- a/lib/pxelinux_cfg.py
+++ b/lib/pxelinux_cfg.py
@@ -123,9 +123,6 @@ def get_boot_record_for_os(node, os_id):
     else:
         image = ''
         # split str same as 'sle-15.1-0.1.1-29.1' to version
-        print('****************************')
-        print(get_os_dir(os_id))
-        print('----------------------------')
         version = \
             re.search(r'(\w+)\-(\d+)\.(\d+)\-(\d+\.\d+\.\d+)\-(\d+\.\d+)',
                       get_os_dir(os_id))
@@ -209,7 +206,9 @@ def refresh_symlinks(os_id, ver):
 
 def provision_node_simulate_fast(node, os_id):
     logging.debug("********************** simulating fast provisioning")
-    time.sleep(3)
+    for i in range(1, 10):
+        logging.debug('sleep, n=%s' % i)
+        time.sleep(1)
     return 1
 
 
@@ -224,8 +223,8 @@ def provision_node_simulate(node, os_id):
 def provision_node_simulate_failure(node, os_id):
     logging.debug("********************** simulating provisioning timeout")
     # timeout is needed for avoid race condition in thread start
-    time.sleep(2)
-    raise TimeoutException("A node have not started in timeout (test mode)")
+    time.sleep(3)
+    raise Exception("A node have not started in timeout (test mode)")
 
 
 def provision_node(node, os_id, extra_sls=[]):

--- a/lib/pxelinux_cfg.py
+++ b/lib/pxelinux_cfg.py
@@ -215,7 +215,9 @@ def provision_node_simulate_fast(node, os_id):
 
 def provision_node_simulate(node, os_id):
     logging.debug("********************** simulating 20 sec provisioning")
-    time.sleep(20)
+    for i in range(1, 20):
+        logging.debug('sleep, n=%s' % i)
+        time.sleep(1)
     return 1
 
 

--- a/test/test_pelagos.py
+++ b/test/test_pelagos.py
@@ -392,7 +392,7 @@ class pelagosTest(unittest.TestCase):
         # scenario:
         # - start node provision #1
         # - start node provision #2
-        # - start node provision #2 for other node
+        # - start node provision #3 for other node
         # - check provision #1 was dismissed, #2 and #3 alive
 
         location1, task_id1 = self.do_flask_task_request(
@@ -408,7 +408,7 @@ class pelagosTest(unittest.TestCase):
         location3, task_id3 = self.do_flask_task_request(
             '/node/provision',
             {'os': os_id,
-             'node': 'test_node'},
+             'node': 'test_node2'},
             'provision #3 ')
         response_stopped = self.app.get(location1)
         self.assertRegex(response_stopped.get_data(as_text=True),
@@ -439,7 +439,7 @@ class pelagosTest(unittest.TestCase):
         # timeout for provision negative tests
         time.sleep(1)
         response_1 = self.app.get(location)
-        logging.debug(prefix + "next level response headers")
+        logging.debug(prefix + " next level response headers")
         logging.debug(response_1.headers)
         self.assertEqual(response_1.status, next_level_status, prefix)
         return location, taskid

--- a/test_pelagos_teuthology/test_pelagos.py
+++ b/test_pelagos_teuthology/test_pelagos.py
@@ -10,10 +10,13 @@ import json
 import shutil
 import os
 
-test_config = dict(pelagos=dict(
-    endpoint='http://localhost:5000/',
-    machine_types='type1,type2',
-))
+test_config = dict(
+    pelagos=dict(
+        endpoint='http://localhost:5000/',
+        machine_types='type1,type2',
+        ),
+    lab_domain=''
+)
 
 test_pxelinux_cfg_root_dir = '/tmp/tftp'
 test_pxelinux_cfg_dir = test_pxelinux_cfg_root_dir + '/pxelinux.cfg'


### PR DESCRIPTION
Added possibility to dismiss provision control. It is needed when
user want to re-provision node while current provisioning is not done.
Also some fixes in multithreading code.