### PR TITLE
Corrected log new line waiting timeout.

### DIFF
--- a/lib/hw_node.py
+++ b/lib/hw_node.py
@@ -19,7 +19,7 @@ salt_cfg_dir = '.'
 sls_list = []
 default_port_lookup_timeout = 5
 default_port_lookup_attempts = 6
-default_conman_line_max_age = 700
+default_conman_line_max_age = 180
 default_cold_restart_timeout = 30
 
 


### PR DESCRIPTION
lib/hw_node.py: timeout for wating new line in log corrected
to be aligned with other timeouts and our  hardware nodes.

Signed-off-by: Roman Grigorev <rgrigorev@suse.de>