### PR TITLE
Fixed file handler leak in logging subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Unit tests are in 'test' subdir and could be executed via
 
     python test/test_pelagos.py
 
+or for specific test case
+   python test/test_pelagos.py pelagosTest.test_provision_log_cleanup 
+
 ### Integration test
 
 Teuthology integration could be tested via  executing 2 commands:

--- a/bin/pelagos.py
+++ b/bin/pelagos.py
@@ -137,7 +137,6 @@ def rmbootrecord_node(node_id):
 def provision_node():
     # start logging for new thread to file ASAP
     # cleanup in flask 'clean_old_taks'
-    threaded_logging.start()
     if request.method != 'POST':
         return abort(405, "Use POST method")
     app.logger.info("Data for provision: [%s]" % str(

--- a/lib/flask_tasks.py
+++ b/lib/flask_tasks.py
@@ -131,6 +131,7 @@ def async_task(target_func):
                         threading.current_thread())
                     tasks[task_id]['log_file'] = threaded_logging. \
                         get_log_name(tasks[task_id]['thread_name'])
+                    tasks[task_id]['log_handler'] = threaded_logging.start()
                     tasks[task_id]['starttime'] = timestamp()
                     tasks[task_id]['endtime'] = -1
                     tasks[task_id]['started'] = True
@@ -155,6 +156,7 @@ def async_task(target_func):
                     # collecting old tasks
                     tasks[task_id]['status'] = 'done'
                     tasks[task_id]['endtime'] = timestamp()
+                    threaded_logging.stop(tasks[task_id]['log_handler'])
                     logging.debug("target function completed")
         # Assign an id to the asynchronous task
         task_id = uuid.uuid4().hex

--- a/lib/threaded_logging.py
+++ b/lib/threaded_logging.py
@@ -87,3 +87,11 @@ def start(thread_name=None):
 
     logging.getLogger().addHandler(log_handler)
     return log_handler
+
+
+def stop(handler):
+    if handler is None:
+        return False
+    logging.getLogger().removeHandler(handler)
+    handler.flush()
+    handler.close()

--- a/test/test_pelagos.py
+++ b/test/test_pelagos.py
@@ -281,6 +281,10 @@ class pelagosTest(unittest.TestCase):
         self.assertRegex(log_data.get_data(as_text=True),
                          r'Found\s+os\s+\[sle-15.1-0.1.1-29.1\]',
                          'Chek log content')
+        self.assertEqual(flask_tasks.tasks[tid]['log_handler'],
+                        logging.getLogger().handlers[2]
+                        )
+
         time.sleep(15)
         logging.debug("Cleanup should happens, check it")
         self.assertFalse(tid in flask_tasks.tasks)
@@ -288,6 +292,8 @@ class pelagosTest(unittest.TestCase):
         removed_log_result = self.app.get('/tasks/log/'+tid)
         self.assertEqual(removed_log_result.status,
                          '404 NOT FOUND', 'Log removed')
+        self.assertEqual(len(logging.getLogger().handlers),2)
+
 
     def test_pxe_provision_node_threaded(self):
         (os_id, test_dir) = self.prepare_correct_boot_env()


### PR DESCRIPTION
When a provision thread execution is ended file handler should be removed
from logger and closed.

bin/pelagos.py: removed log start call
lib/flask_tasks.py: added log start and stop calls
lib/threaded_logging.py: implemented log stop call (remove  log handler and
 close it)
test/test_pelagos.py: added checks for log handler cleanup